### PR TITLE
corrigiendo violaciones a principios SOLID DIP y OCP

### DIFF
--- a/programas/tresEnRaya_Arbol/src/tresenrayadecision/objects/Cadena.java
+++ b/programas/tresEnRaya_Arbol/src/tresenrayadecision/objects/Cadena.java
@@ -2,7 +2,7 @@ package tresenrayadecision.objects;
 
 import java.util.Iterator;
 
-public class Cadena<E> {
+public abstract class Cadena<E> {
 
     protected Cadena.Nodo<E> raiz;
 


### PR DESCRIPTION
**Violación de DIP - dependency inversion principle**
La clase CadenaOrdenada extiende de Cadena, sin embargo Cadena no es abstracta. Esto implica que no dependen de abstracciones.

**Violación de OCP - open closed principle**
También debido a Cadena y CadenaOrdenada. Si se desean agregar otros subtipos de estructura Cadena se está obligado a cambiar la clase Cadena debido a que no es abstracta.

**Solución**
Simplemente hacer que la clase Cadena sea abstracta

Diagrama de clases luego del cambio |
--- |
![diagramaClase_TresEnRaya_Despues](https://user-images.githubusercontent.com/73547550/123392713-fe9ac800-d562-11eb-98cf-4ae257fdafff.png) |




